### PR TITLE
fix: Partial fix for FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ project(fdict
   DESCRIPTION "Fortran dictionary for arbitrary data-types"
 )
 
+if (NOT DEFINED CMAKE_Fortran_MODULE_DIRECTORY)
+	set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran_modules)
+endif ()
+
 # Project installation follows GNU installation directory convention
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ list(APPEND FYPPFLAGS
 )
 
 # Add project options
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/fdictOptions.cmake")
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/fdictFyppify.cmake")
+include(cmake/fdictOptions.cmake)
+include(cmake/fdictFyppify.cmake)
 
 # create library.
 add_subdirectory(src)
@@ -58,11 +58,10 @@ add_subdirectory(src)
 # Now for installing stuff.
 
 # Generate the version include file
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/fdict.inc.in"
-	"${CMAKE_CURRENT_BINARY_DIR}/fdict.inc"
-	@ONLY
-)
+# TODO: This file should not be necessary
+#  This file is already parsed in the preprocessor
+#  Instead move this information into fortran functions to extract the version
+configure_file(fdict.inc.in fdict.inc)
 install(
   FILES
 	  "${CMAKE_CURRENT_BINARY_DIR}/fdict.inc"
@@ -71,6 +70,7 @@ install(
 
 # Globally define a place where we will install
 # cmake configuration stuff, *Target.cmake *Version.cmake etc.
+# TODO: Do not set cache variables that can conflict with variables in other projects
 set(CMAKE_INSTALL_CMAKECONFIG_DIR
   "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   CACHE STRING
@@ -80,11 +80,7 @@ mark_as_advanced(CMAKE_INSTALL_CMAKECONFIG_DIR)
 
 
 # Create pkg-config file
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/fdict.pc.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-  @ONLY
-)
+configure_file(fdict.pc.in fdict.pc @ONLY)
 install(
   FILES
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # The output directory of the module files
 set(LIB_MOD_DIR "${CMAKE_CURRENT_BINARY_DIR}/modules")
 if(NOT EXISTS "${LIB_MOD_DIR}")
-  make_directory("${LIB_MOD_DIR}")
+  file(MAKE_DIRECTORY "${LIB_MOD_DIR}")
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,5 @@
 # Make CMake run the scripts for creating the input files
 
-# The output directory of the module files
-set(LIB_MOD_DIR "${CMAKE_CURRENT_BINARY_DIR}/modules")
-if(NOT EXISTS "${LIB_MOD_DIR}")
-  file(MAKE_DIRECTORY "${LIB_MOD_DIR}")
-endif()
-
 
 # Do the preprocessing
 fdict_fyppify(
@@ -42,12 +36,6 @@ install(
 
 # Finally define the fdict library
 add_library(${PROJECT_NAME} ${fdict_sources})
-
-# Attach the headers to the target
-set_target_properties(${PROJECT_NAME}
-  PROPERTIES
-  POSITION_INDEPENDENT_CODE ON
-)
 
 # Install all modules (omitting the directory)
 # TODO: Move to single module interface and move the other modules to subfolder

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,18 +47,23 @@ add_library(${PROJECT_NAME} ${fdict_sources})
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
   POSITION_INDEPENDENT_CODE ON
-  Fortran_MODULE_DIRECTORY "${LIB_MOD_DIR}"
 )
 
 # Install all modules (omitting the directory)
-install(DIRECTORY "${LIB_MOD_DIR}/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+# TODO: Move to single module interface and move the other modules to subfolder
+#  This is to avoid name-clashing (similar to how C projects structure their include)
+install(FILES
+		${CMAKE_Fortran_MODULE_DIRECTORY}/dictionary.mod
+		${CMAKE_Fortran_MODULE_DIRECTORY}/variable.mod
+		${CMAKE_Fortran_MODULE_DIRECTORY}/fdict_types.mod
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Ensure that the target contains the headers/modules/include files
 # and that it gets exported with the Targets output
 target_include_directories(${PROJECT_NAME}
-  INTERFACE
-  $<BUILD_INTERFACE:"${LIB_MOD_DIR}">
-  $<INSTALL_INTERFACE:"${CMAKE_INSTALL_INCLUDEDIR}">
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Install the library targets


### PR DESCRIPTION
Partial fix for FetchContent issue regarding:
```
CMake Error in CMakeLists.txt:
  Target "fdict" contains relative path in its INTERFACE_INCLUDE_DIRECTORIES:
```

Issue is that generator expression should not have quotation marks there. A few other issues here are:
- Use `CMake_Fortran_MODULE_DIRECTORY` instead of setting the specific target property. This makes it consistent with downstream user's configuration
- `target_include_directories` should be `PUBLIC`, not `INTERFACE` there. I.e. the library should be using it as well. This is a compiler dependent behaviour because some might be automatically be using `Fortran_MODULE_DIRECTOR` or not, and this addresses the issue of the latter

Note on the "partial" fix. This is because the install interface is not fixed yet according to #32 