### PR TITLE
ci: Add Fedora packaging

### DIFF
--- a/.distro/.gitignore
+++ b/.distro/.gitignore
@@ -1,0 +1,5 @@
+/main.fmf
+/plans/main.fmf
+/tests/main.fmf
+!*.spec
+*.tar.gz

--- a/.distro/fdict.spec
+++ b/.distro/fdict.spec
@@ -1,0 +1,42 @@
+Name:           fdict
+Version:        0.0.0
+Release:        %{autorelease}
+Summary:        Fortran type-free variable and type-free dictionary
+
+License:        GPL-2.0
+URL:            http://zerothi.github.io/fdict
+Source:         https://github.com/zerothi/fdict/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  cmake
+BuildRequires:  gcc-gfortran
+
+%description
+A variable and dictionary in pure fortran for retaining any data-type and a
+fast hash-table dictionary.
+
+
+%prep
+%autosetup -p1 -n fdict-%{version}
+
+
+%build
+%cmake
+%cmake_build
+
+
+%install
+%cmake_install
+
+
+%check
+%ctest
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/cmake/fdict
+
+
+%changelog
+%autochangelog

--- a/.distro/packit.toml
+++ b/.distro/packit.toml
@@ -1,0 +1,3 @@
+Filters = [
+    "unknown-key",
+]

--- a/.distro/plans/main.fmf.dist-git
+++ b/.distro/plans/main.fmf.dist-git
@@ -1,0 +1,3 @@
+discover:
+  how: fmf
+  dist-git-source: true

--- a/.distro/plans/rpmlint.fmf
+++ b/.distro/plans/rpmlint.fmf
@@ -1,0 +1,22 @@
+summary:
+  Perform rpmlint and rpminspect tests
+prepare:
+  - name: Install rpmlint packages
+    how: install
+    package:
+    - rpmlint
+    - rpminspect
+    - rpminspect-data-fedora
+  ## TODO: Disabled because upstream failure
+  ## https://github.com/packit/packit/issues/1978
+  #- name: Download the source rpm
+  #  how: shell
+  #  script: cd /tmp && curl -O ${PACKIT_SRPM_URL}
+  - name: Download rpm packages
+    how: shell
+    script: cd /tmp && dnf download ${PACKIT_COPR_RPMS}
+discover+:
+  how: fmf
+  filter: "tag: rpmlint"
+execute:
+    how: tmt

--- a/.distro/plans/smoke.fmf
+++ b/.distro/plans/smoke.fmf
@@ -1,0 +1,7 @@
+summary:
+  Basic smoke tests
+discover+:
+  how: fmf
+  filter: "tag: smoke"
+execute:
+    how: tmt

--- a/.distro/tests/rpmlint.fmf
+++ b/.distro/tests/rpmlint.fmf
@@ -1,0 +1,13 @@
+# Common test variables
+tag:
+  - rpmlint
+tier: 0
+path: /
+
+# Define tests
+/rpmlint:
+  summary: Rpmlint spec and rpmfiles
+  test: rpmlint -c packit.toml -r fidct.rpmlintrc ./*.spec /tmp/*.rpm
+/rpminspect-rpms:
+  summary: Rpminspect the rpms
+  test: ls /tmp/*.rpm | xargs -L1 rpminspect-fedora -E metadata,disttag

--- a/.distro/tests/smoke.fmf
+++ b/.distro/tests/smoke.fmf
@@ -1,0 +1,9 @@
+# Common test variables
+tag:
+  - smoke
+tier: 0
+path: /
+
+# Define tests
+/version:
+  test: echo "To be implemented"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,80 @@
+specfile_path: .distro/fdict.spec
+files_to_sync:
+  - src: .distro/fdict.spec
+    dest: fdict.spec
+  - .packit.yaml
+  - src: .distro/fdict.rpmlintrc
+    dest: fdict.rpmlintrc
+  # tmt setup
+  - src: .distro/.fmf/
+    dest: .fmf/
+  - src: .distro/plans/
+    dest: plans/
+    filters:
+      - "- .distro/plans/main.fmf.dist-git"
+      - "- .distro/plans/rpmlint.fmf"
+  - src: .distro/plans/main.fmf.dist-git
+    dest: plans/main.fmf
+
+upstream_package_name: fdict
+downstream_package_name: fdict
+update_release: false
+upstream_tag_template: v{version}
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    owner: lecris
+    project: fdict
+    update_release: true
+    release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
+    targets:
+      # TODO: Change before production
+      #- fedora-development
+      - fedora-all
+  - job: tests
+    trigger: pull_request
+    targets:
+      # TODO: Change before production
+      #- fedora-development
+      - fedora-all
+    fmf_path: .distro
+  - job: copr_build
+    trigger: commit
+    branch: main
+    owner: lecris
+    project: nightly
+    targets:
+      - fedora-all-x86_64
+      - fedora-all-aarch64
+    additional_repos:
+      - copr://@scikit-build/release
+  - job: tests
+    trigger: commit
+    branch: main
+    targets:
+      - fedora-all
+  - job: copr_build
+    trigger: release
+    owner: lecris
+    project: release
+    targets:
+      - fedora-all-x86_64
+      - fedora-all-aarch64
+    additional_repos:
+      # TODO: Required for now until related issue is resolved
+      # https://github.com/packit/packit/issues/1917
+      - copr://@scikit-build/release
+## TODO: Disabled until released on src.fedoraproject.org
+#  - job: propose_downstream
+#    trigger: release
+#    dist_git_branches:
+#      - fedora-development
+#  - job: koji_build
+#    trigger: commit
+#    dist_git_branches:
+#      - fedora-all
+#  - job: bodhi_update
+#    trigger: commit
+#    dist_git_branches:
+#      - fedora-all


### PR DESCRIPTION
If you want to make this package available on Fedora, it is quite simple these days and there are CI tools that help you automate this. Here is the CI for Fedora packaging. You need to install [packit service](https://packit.dev/docs/guide/) to enable this (and 1 more verification step that I can handle with packit upstream).

Other benefits of this:
- Can test cmake's `find_package` and `FetchContent` as if it was installed on the system (or not)
- Tests multiple architectures and dependencies on various Fedora release packages (after ctest is added)